### PR TITLE
Added separator between "Switch Theme" and "Exit" under _menu_bar.

### DIFF
--- a/bl_predictor/gui.py
+++ b/bl_predictor/gui.py
@@ -115,6 +115,7 @@ class MainWindow:
         menu_bar.add_cascade(label="Options", menu=switch_theme_menu)
         switch_theme_menu.add_command(
             label="Switch Theme", command=self.switch_theme)
+        switch_theme_menu.add_separator()
         switch_theme_menu.add_command(label="Exit", command=self.root.destroy)
 
     def switch_theme(self):


### PR DESCRIPTION
Adds a separator widget between "Switch Theme" and "Exit" button under  the "Options" button of the menu bar.